### PR TITLE
Add ssl_ca_path parameter to Net::Jabber::Client::Connect() call

### DIFF
--- a/jabber-notify.pl
+++ b/jabber-notify.pl
@@ -90,7 +90,8 @@ my $status = $Connection->Connect(
   "hostname" => $XMPPServ,
   "port" => $XMPPPort,
   "componentname" => $XMPPDomain,
-  "tls" => $XMPPTLS );
+  "tls" => $XMPPTLS,
+  "ssl_ca_path" => "/etc/ssl/certs" );
 
 
 


### PR DESCRIPTION
`ssl_ca_path` is a required parameter for SSL/TLS connections, Net::Jabber::Client complains if it is not present (`Invalid or unreadable path specified for ssl_ca_path`).